### PR TITLE
driver, utils: Connect to the remote sheepdog

### DIFF
--- a/etc/dockerdriver.json
+++ b/etc/dockerdriver.json
@@ -5,5 +5,9 @@
     "TargetIqn": "iqn.2017-09.org.sheepdog-project",
     "TargetBindIP": "127.0.0.1",
     "TargetBindPort": "3260",
-    "VdiSuffix": "dvp"
+    "VdiSuffix": "dvp",
+    "LocalSheepSocket": "/var/lib/sheepdog/sock",
+    "RemoteSheep": false,
+    "RemoteSheepIP": "127.0.0.1",
+    "RemoteSheepPort": "7000"
 }


### PR DESCRIPTION
We can now connect to the remote sheepdog as well as localhost.
Specify that setting in json config file.

Please be careful that this change includes the interface change of
utility

Fix: #7

Signed-off-by: Kazuhisa Hara <khara@sios.com>