### PR TITLE
driver: Hide unnecessary errors if it succeeds on vdi remove

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -227,7 +227,6 @@ func (d SheepdogDriver) Remove(r volume.Request) volume.Response {
 	log.Debug("remove path: ", path)
 	if err := os.Remove(path); err != nil {
 		log.Errorf("Failed to remove Mount directory: %v", err)
-		return volume.Response{Err: err.Error()}
 	}
 	return volume.Response{}
 }


### PR DESCRIPTION
In the following cases, we were replying unnecessary errors to the
client.

- vdi is exist (dvp-vol1)
- mount point is not exist (/mnt/sheepdog/vol1 deleted)

If remove of vdi is complete without any problem, the user does not want
to see this error.
It would be sufficient to keep it as a daemon log.

Fix: #14

Signed-off-by: Kazuhisa Hara <khara@sios.com>